### PR TITLE
Improve efficiency of skill retrieval and query handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ python server.py --run-tests
 
 The MCP server provides the following tools:
 
-1. **run_sentinel_query**: Execute KQL queries in Sentinel
+1. **run_sentinel_query**: Execute KQL queries in Sentinel. Accepts an optional
+   `to_dataframe` parameter to skip DataFrame creation when set to `False`.
 2. **get_skillsets**: List skillsets in Security Copilot
 3. **upload_plugin**: Upload or update a skillset/plugin
 4. **run_prompt**: Run a prompt or skill in Security Copilot

--- a/SecurityCopilotClient.py
+++ b/SecurityCopilotClient.py
@@ -3,6 +3,7 @@ import requests
 from azure.identity import InteractiveBrowserCredential, ClientSecretCredential, DefaultAzureCredential
 import yaml
 import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 # Get logger
 logger = logging.getLogger('SecurityCopilotMCP')
@@ -77,26 +78,26 @@ class SecurityCopilotClient:
                 continue
             filtered_skillsets.append(skillset)
         
-        if full_response:   
-            # For each skillset, get its skills
+        if full_response:
+            # Fetch skills for each skillset in parallel to reduce latency
             skillsets_with_skills = []
-            for skillset in filtered_skillsets:
-                # Apply filter if provided
-                
-                    
-                # Get skills for this skillset
+
+            def fetch_skills(skillset):
                 skills_url = f"{self.base_url}/geo/{self.region}/skillsets/{skillset['name']}/skills"
-                skills_response = requests.get(skills_url, headers=headers)
-                
-                if skills_response.status_code == 200:
+                try:
+                    skills_response = requests.get(skills_url, headers=headers)
+                    skills_response.raise_for_status()
                     skills_data = skills_response.json()
-                    # Add skills to skillset
                     skillset['skills'] = skills_data.get('value', [])
-                else:
-                    # If skills can't be retrieved, add empty list
+                except Exception as e:
+                    logger.error(f"Failed to fetch skills for {skillset['name']}: {e}")
                     skillset['skills'] = []
-                    
-                skillsets_with_skills.append(skillset)
+                return skillset
+
+            with ThreadPoolExecutor() as executor:
+                futures = [executor.submit(fetch_skills, s) for s in filtered_skillsets]
+                for future in as_completed(futures):
+                    skillsets_with_skills.append(future.result())
             
             return {
                 "count": len(skillsets_with_skills),

--- a/SentinelClient.py
+++ b/SentinelClient.py
@@ -23,8 +23,16 @@ class SentinelClient:
         self.credential=credential
         self.logs_client=LogsQueryClient(self.credential)
 
-    def run_query(self,query,printresults=False):
-        results_object={}
+    def run_query(self, query, printresults=False, to_dataframe=True):
+        """Run a KQL query and return the results.
+
+        Args:
+            query (str): KQL query to execute.
+            printresults (bool): Whether to print the results.
+            to_dataframe (bool): Return results as DataFrame if True, otherwise
+                return a list of dictionaries without creating a DataFrame.
+        """
+        results_object = {}
         try:
             response = self.logs_client.query_workspace(
                 workspace_id=self.workspace_id,
@@ -38,10 +46,16 @@ class SentinelClient:
             elif response.status == LogsQueryStatus.SUCCESS:
                 data = response.tables
             for table in data:
-                df = pd.DataFrame(data=table.rows, columns=table.columns)
-                if printresults:
-                    print(df)
-                results_object={"status":"success","result":df.to_dict(orient="records")}
+                if to_dataframe:
+                    df = pd.DataFrame(data=table.rows, columns=table.columns)
+                    if printresults:
+                        print(df)
+                    results = df.to_dict(orient="records")
+                else:
+                    results = [dict(zip(table.columns, row)) for row in table.rows]
+                    if printresults:
+                        print(results)
+                results_object = {"status": "success", "result": results}
         except HttpResponseError as err:
             results_object={"status":"error","result":err}
         return results_object


### PR DESCRIPTION
## Summary
- parallelize skill retrieval for skillsets using `ThreadPoolExecutor`
- add `to_dataframe` option in `SentinelClient.run_query`
- document new parameter in README

## Testing
- `python -m py_compile SecurityCopilotClient.py SentinelClient.py server.py`